### PR TITLE
Fixed a simple headache

### DIFF
--- a/SwerveModule.py
+++ b/SwerveModule.py
@@ -7,7 +7,7 @@ from wpilib import controller as controller
 class SwerveModule:
 	wheelDiameter = 4 #inches
 	turnMotorEncoderConversion = 20 #NEO encoder gives 0-18 as 1 full rotation
-	absoluteEncoderConversion = .08877
+	absoluteEncoderConversion = .1598
 	
 	def __init__(self,driveID,turnID,encoderID,encoderOffset,name):
 		if name == "Front Left":
@@ -116,7 +116,7 @@ class SwerveModule:
 	def checkEncoders(self):
 		absolutePosition = self.absoluteEncoder.getValue()*self.absoluteEncoderConversion
 		position = self.encoderBoundedPosition()
-		wpilib.SmartDashboard.putNumber(self.moduleName,absolutePosition)
+		wpilib.SmartDashboard.putNumber(self.moduleName + "ABS",absolutePosition)
 		wpilib.SmartDashboard.putNumber(self.moduleName + " NEO",position)
 		
 	def autoPosition(self):


### PR DESCRIPTION
conversion value seemed to be outdated leading to absolute encoders givings values of 0-200 instead of 0-360, in heinsight I should have seen this issue right away however I just assumed the value was always correct so never saw it coming. Now gives proper reading of 0-360. Also added a QOL change for the UI.